### PR TITLE
Add admin audit log hook and user log section

### DIFF
--- a/app/(platform)/admin/_components/admin-activity-log.tsx
+++ b/app/(platform)/admin/_components/admin-activity-log.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useMemo } from "react";
+import { AlertCircle, Clock, UserCheck } from "lucide-react";
+import { format } from "date-fns";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useAdminAuditLogs } from "@/hooks/use-admin-logs";
+import { AuditLogQuery } from "@/lib/actions/admin/admin-log-action";
+import { LogType } from "@/models/log/logDTO";
+
+type AdminActivityLogProps = {
+  title?: string;
+  description?: string;
+  filter: AuditLogQuery;
+  emptyMessage?: string;
+};
+
+const formatLogType = (logType?: LogType) => {
+  if (!logType) return "";
+  return logType.replace(/_/g, " ");
+};
+
+const formatDateTime = (value?: Date | string) => {
+  if (!value) return "";
+  return format(new Date(value), "dd/MM/yyyy HH:mm");
+};
+
+export function AdminActivityLog({
+  title = "Log hoạt động",
+  description = "Theo dõi các thao tác quản trị",
+  filter,
+  emptyMessage = "Chưa có log nào",
+}: AdminActivityLogProps) {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError, refetch } =
+    useAdminAuditLogs(filter);
+
+  const logs = useMemo(() => data?.pages.flatMap((page) => page.data) ?? [], [data]);
+
+  return (
+    <div className="rounded-2xl border border-sky-100 bg-white p-4 shadow-sm">
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-base font-semibold text-slate-800">{title}</h3>
+          <p className="text-sm text-slate-500">{description}</p>
+        </div>
+        {filter.logType && (
+          <Badge className="bg-sky-100 text-sky-700 hover:bg-sky-100">
+            {formatLogType(filter.logType)}
+          </Badge>
+        )}
+      </div>
+
+      <div className="overflow-x-auto rounded-xl border border-slate-100">
+        <Table className="min-w-[720px]">
+          <TableHeader className="bg-slate-50/60">
+            <TableRow>
+              <TableHead className="w-[180px]">Thời gian</TableHead>
+              <TableHead>Hành động</TableHead>
+              <TableHead>Chi tiết</TableHead>
+              <TableHead className="w-[160px]">Người thực hiện</TableHead>
+              <TableHead className="w-[160px]">Đối tượng</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isLoading &&
+              Array.from({ length: 5 }).map((_, idx) => (
+                <TableRow key={`sk-${idx}`}>
+                  <TableCell className="animate-pulse text-slate-400">Đang tải...</TableCell>
+                  <TableCell className="animate-pulse text-slate-300">&nbsp;</TableCell>
+                  <TableCell className="animate-pulse text-slate-300">&nbsp;</TableCell>
+                  <TableCell className="animate-pulse text-slate-300">&nbsp;</TableCell>
+                  <TableCell className="animate-pulse text-slate-300">&nbsp;</TableCell>
+                </TableRow>
+              ))}
+
+            {!isLoading && logs.length === 0 && !isError ? (
+              <TableRow>
+                <TableCell colSpan={5} className="py-8 text-center text-slate-500">
+                  {emptyMessage}
+                </TableCell>
+              </TableRow>
+            ) : null}
+
+            {isError ? (
+              <TableRow>
+                <TableCell colSpan={5} className="py-8 text-center text-red-600">
+                  Không thể tải log hoạt động. <Button variant="link" onClick={() => refetch()}>Thử lại</Button>
+                </TableCell>
+              </TableRow>
+            ) : null}
+
+            {!isLoading && !isError
+              ? logs.map((log) => (
+                  <TableRow key={log.id} className="hover:bg-slate-50/80">
+                    <TableCell className="text-slate-600">
+                      <div className="flex items-center gap-2">
+                        <Clock className="h-4 w-4 text-slate-400" />
+                        {formatDateTime(log.createdAt)}
+                      </div>
+                    </TableCell>
+                    <TableCell className="font-medium text-slate-800">{log.action}</TableCell>
+                    <TableCell className="text-slate-600">{log.detail}</TableCell>
+                    <TableCell className="text-slate-600">
+                      <div className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs text-slate-700">
+                        <UserCheck className="h-4 w-4" />
+                        {log.actorId}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-slate-600">{log.targetId}</TableCell>
+                  </TableRow>
+                ))
+              : null}
+          </TableBody>
+        </Table>
+      </div>
+
+      <div className="mt-4 flex items-center justify-between">
+        <div className="flex items-center gap-2 text-sm text-slate-500">
+          <AlertCircle className="h-4 w-4" />
+          {logs.length} log đang hiển thị
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isFetchingNextPage || isLoading}>
+            Làm mới
+          </Button>
+          {hasNextPage && (
+            <Button size="sm" onClick={() => fetchNextPage()} disabled={isFetchingNextPage}>
+              {isFetchingNextPage ? "Đang tải..." : "Tải thêm"}
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(platform)/admin/users/_components/toolbar.tsx
+++ b/app/(platform)/admin/users/_components/toolbar.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import * as React from 'react';
-import { Search, RotateCcw } from 'lucide-react';
+import { Search, RotateCcw, Filter } from 'lucide-react';
+
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -11,10 +12,38 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { SystemUserFilter } from '@/lib/actions/admin/admin-users-action';
+import { UserStatus } from '@/models/user/systemUserDTO';
 
-export function UsersToolbar() {
-  const [q, setQ] = React.useState('');
-  const [status, setStatus] = React.useState<string>('all');
+type UsersToolbarProps = {
+  filter: SystemUserFilter;
+  onFilterChange: (changes: Partial<SystemUserFilter>) => void;
+  onReset: () => void;
+};
+
+export function UsersToolbar({ filter, onFilterChange, onReset }: UsersToolbarProps) {
+  const [q, setQ] = React.useState(filter.query ?? '');
+  const [status, setStatus] = React.useState<string>(filter.status ?? 'all');
+
+  React.useEffect(() => {
+    setQ(filter.query ?? '');
+  }, [filter.query]);
+
+  React.useEffect(() => {
+    setStatus(filter.status ?? 'all');
+  }, [filter.status]);
+
+  const applyFilters = () => {
+    onFilterChange({
+      query: q.trim() ? q.trim() : undefined,
+      status: status === 'all' ? undefined : (status as UserStatus),
+      page: 1,
+    });
+  };
+
+  const handleStatusChange = (value: string) => {
+    setStatus(value);
+  };
 
   return (
     <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
@@ -30,6 +59,11 @@ export function UsersToolbar() {
             <Input
               value={q}
               onChange={(e) => setQ(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  applyFilters();
+                }
+              }}
               placeholder="Tên hoặc email..."
               className="pl-9 border-sky-100 focus-visible:ring-sky-200"
             />
@@ -41,37 +75,33 @@ export function UsersToolbar() {
           <div className="mb-1 text-xs font-medium text-slate-500">
             Trạng thái
           </div>
-          <Select value={status} onValueChange={setStatus}>
+          <Select value={status} onValueChange={handleStatusChange}>
             <SelectTrigger className="border-sky-100 focus:ring-sky-200">
               <SelectValue placeholder="Chọn trạng thái" />
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="all">Tất cả</SelectItem>
-              <SelectItem value="active">Hoạt động</SelectItem>
-              <SelectItem value="inactive">Bị khóa</SelectItem>
+              <SelectItem value={UserStatus.ACTIVE}>Hoạt động</SelectItem>
+              <SelectItem value={UserStatus.BANNED}>Bị khóa</SelectItem>
+              <SelectItem value={UserStatus.DELETED}>Đã xóa</SelectItem>
             </SelectContent>
           </Select>
-        </div>
-
-        {/* Ngày tham gia */}
-        <div>
-          <div className="mb-1 text-xs font-medium text-slate-500">
-            Ngày tham gia
-          </div>
-          <Input
-            type="date"
-            className="border-sky-100 focus-visible:ring-sky-200"
-          />
         </div>
       </div>
 
       {/* CỤM PHẢI: actions */}
       <div className="flex items-center gap-2 sm:justify-end">
-        <Button>Lọc</Button>
-
+        <Button
+          className="bg-sky-600 text-white hover:bg-sky-700"
+          onClick={applyFilters}
+        >
+          <Filter className="mr-2 h-4 w-4" />
+          Lọc
+        </Button>
         <Button
           variant="outline"
           className="border-sky-200 text-slate-700 hover:bg-sky-50"
+          onClick={onReset}
         >
           <RotateCcw className="mr-1 h-4 w-4" />
           Đặt lại

--- a/app/(platform)/admin/users/_components/user-detail-dialog.tsx
+++ b/app/(platform)/admin/users/_components/user-detail-dialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import type { UserDTO } from '@/models/user/userDTO';
+import React from 'react';
+import type { SystemUserDTO } from '@/models/user/systemUserDTO';
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
@@ -10,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { SystemRole, UserStatus } from '@/models/user/systemUserDTO';
 import { formatDateVN, getFullName } from '@/utils/user.utils';
 
 function initials(name: string) {
@@ -17,97 +19,91 @@ function initials(name: string) {
   return (parts[0]?.[0] ?? 'U') + (parts[parts.length - 1]?.[0] ?? '');
 }
 
+const roleLabels: Record<SystemRole, string> = {
+  [SystemRole.ADMIN]: 'Quản trị viên',
+  [SystemRole.MODERATOR]: 'Điều hành viên',
+  [SystemRole.USER]: 'Người dùng',
+};
+
+function LabelValue({
+  label,
+  value,
+}: {
+  label: string;
+  value: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-xl border border-sky-100 bg-white p-3">
+      <div className="text-xs font-medium text-slate-500">{label}</div>
+      <div className="mt-1 text-sm font-semibold text-slate-800">{value}</div>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: UserStatus }) {
+  if (status === UserStatus.ACTIVE)
+    return (
+      <Badge className="bg-emerald-100 text-emerald-700 hover:bg-emerald-100">
+        HOẠT ĐỘNG
+      </Badge>
+    );
+
+  if (status === UserStatus.BANNED)
+    return (
+      <Badge variant="secondary" className="bg-rose-100 text-rose-700 hover:bg-rose-100">
+        BỊ KHÓA
+      </Badge>
+    );
+
+  return (
+    <Badge variant="secondary" className="bg-slate-100 text-slate-700 hover:bg-slate-100">
+      ĐÃ XÓA
+    </Badge>
+  );
+}
+
 export function UserDetailDialog({
   user,
   open,
   onOpenChange,
 }: {
-  user: UserDTO | null;
+  user: SystemUserDTO | null;
   open: boolean;
   onOpenChange: (v: boolean) => void;
 }) {
   if (!user) return null;
 
-  const name = getFullName(user);
+  const name = getFullName(user) || user.email || 'Người dùng';
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-[720px] border-sky-100">
+      <DialogContent className="max-w-[640px] border-sky-100">
         <DialogHeader>
-          <DialogTitle className="text-slate-800">
-            Thông tin người dùng
-          </DialogTitle>
+          <DialogTitle className="text-slate-800">Thông tin người dùng</DialogTitle>
         </DialogHeader>
 
-        {/* Cover */}
-        <div className="relative rounded-xl border border-sky-100 bg-sky-50">
-          {/* chỉ cover mới overflow-hidden */}
-          <div className="overflow-hidden rounded-xl">
-            <div
-              className="h-28 w-full bg-linear-to-r from-sky-100 via-white to-sky-100"
-              style={
-                user.coverImageUrl
-                  ? {
-                      backgroundImage: `url(${user.coverImageUrl})`,
-                      backgroundSize: 'cover',
-                      backgroundPosition: 'center',
-                    }
-                  : undefined
-              }
-            />
-          </div>
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:gap-5">
+          <Avatar className="h-16 w-16 ring-2 ring-white shadow-sm">
+            <AvatarImage src={user.avatarUrl} />
+            <AvatarFallback>{initials(name)}</AvatarFallback>
+          </Avatar>
 
-          {/* Avatar + info */}
-          <div className="absolute left-4 bottom-0 flex items-end gap-3">
-            <Avatar className="h-16 w-16 ring-2 ring-white shadow-sm">
-              <AvatarImage src={user.avatarUrl} />
-              <AvatarFallback>{initials(name)}</AvatarFallback>
-            </Avatar>
-
-            <div className="pb-1">
-              <div className="text-lg font-semibold text-slate-800">{name}</div>
-              <div className="text-sm text-slate-500">{user.email}</div>
-            </div>
-          </div>
-
-          {/* spacer để nội dung bên dưới không bị đè */}
-          <div className="h-14" />
-        </div>
-
-        {/* Info */}
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-          <div className="rounded-xl border border-sky-100 bg-white p-3">
-            <div className="text-xs text-slate-500">Trạng thái</div>
-            <div className="mt-1">
-              {user.isActive ? (
-                <Badge className="bg-sky-100 text-sky-700 hover:bg-sky-100">
-                  HOẠT ĐỘNG
-                </Badge>
-              ) : (
-                <Badge
-                  variant="secondary"
-                  className="bg-slate-100 text-slate-600 hover:bg-slate-100"
-                >
-                  BỊ KHÓA
-                </Badge>
-              )}
-            </div>
-          </div>
-
-          <div className="rounded-xl border border-sky-100 bg-white p-3">
-            <div className="text-xs text-slate-500">Ngày tham gia</div>
-            <div className="mt-1 text-sm font-medium text-slate-800">
-              {formatDateVN(user.createdAt)}
+          <div className="space-y-1">
+            <div className="text-lg font-semibold text-slate-800">{name}</div>
+            <div className="text-sm text-slate-500">{user.email}</div>
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant="outline" className="border-amber-200 bg-amber-50 text-amber-700">
+                {roleLabels[user.role]}
+              </Badge>
+              <StatusBadge status={user.status} />
             </div>
           </div>
         </div>
 
-        {/* Bio */}
-        <div className="rounded-xl border border-sky-100 bg-white p-3">
-          <div className="text-xs text-slate-500">Tiểu sử</div>
-          <p className="mt-1 text-sm text-slate-700">
-            {user.bio || 'Chưa có thông tin tiểu sử.'}
-          </p>
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <LabelValue label="Mã người dùng" value={user.id} />
+          <LabelValue label="Email" value={user.email} />
+          <LabelValue label="Ngày tham gia" value={formatDateVN(user.createdAt)} />
         </div>
       </DialogContent>
     </Dialog>

--- a/app/(platform)/admin/users/page.tsx
+++ b/app/(platform)/admin/users/page.tsx
@@ -1,15 +1,32 @@
+"use client";
+
+import * as React from "react";
+
+import { useSystemUsers } from "@/hooks/use-admin-users";
+import { SystemUserFilter } from "@/lib/actions/admin/admin-users-action";
+import { LogType } from "@/models/log/logDTO";
+import { AdminActivityLog } from "../_components/admin-activity-log";
 import { UsersTable } from "./_components/table";
 import { UsersToolbar } from "./_components/toolbar";
 
-
 export default function AdminUsersPage() {
+  const [filter, setFilter] = React.useState<SystemUserFilter>({ page: 1, limit: 10 });
+
+  const { data, isLoading, isFetching } = useSystemUsers(filter);
+
+  const handleFilterChange = (changes: Partial<SystemUserFilter>) => {
+    setFilter((prev) => ({ ...prev, ...changes }));
+  };
+
+  const handleReset = () => {
+    setFilter({ page: 1, limit: filter.limit ?? 10 });
+  };
+
   return (
     <div className="space-y-5">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-xl font-semibold text-slate-800">
-            Quản lý người dùng
-          </h1>
+          <h1 className="text-xl font-semibold text-slate-800">Quản lý người dùng</h1>
           <p className="text-sm text-slate-500">
             Theo dõi tài khoản, trạng thái hoạt động và thông tin hồ sơ
           </p>
@@ -17,11 +34,25 @@ export default function AdminUsersPage() {
       </div>
 
       <div className="rounded-2xl border border-sky-100 bg-white p-4 shadow-sm">
-        <UsersToolbar />
+        <UsersToolbar filter={filter} onFilterChange={handleFilterChange} onReset={handleReset} />
         <div className="mt-4">
-          <UsersTable />
+          <UsersTable
+            users={data?.data ?? []}
+            page={data?.page ?? filter.page ?? 1}
+            pageSize={data?.limit ?? filter.limit ?? 10}
+            total={data?.total ?? 0}
+            loading={isLoading || isFetching}
+            onPageChange={(page) => setFilter((prev) => ({ ...prev, page }))}
+          />
         </div>
       </div>
+
+      <AdminActivityLog
+        title="Log hoạt động người dùng"
+        description="Theo dõi thao tác quản trị liên quan đến tài khoản"
+        filter={{ logType: LogType.USER_LOG, limit: 10 }}
+        emptyMessage="Chưa có hoạt động nào liên quan đến người dùng"
+      />
     </div>
   );
 }

--- a/hooks/use-admin-logs.ts
+++ b/hooks/use-admin-logs.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useAuth } from '@clerk/nextjs';
+
+import { getAuditLogs, AuditLogQuery } from '@/lib/actions/admin/admin-log-action';
+import { CursorPageResponse } from '@/lib/cursor-pagination.dto';
+import { AuditLogResponseDTO } from '@/models/log/logDTO';
+
+export const useAdminAuditLogs = (filter: AuditLogQuery) => {
+  const { getToken } = useAuth();
+
+  return useInfiniteQuery<CursorPageResponse<AuditLogResponseDTO>>({
+    queryKey: ['admin-audit-logs', filter],
+    initialPageParam: undefined,
+    queryFn: async ({ pageParam }) => {
+      const token = await getToken();
+      if (!token) throw new Error('Token is required');
+
+      return getAuditLogs(token, { ...filter, cursor: pageParam });
+    },
+    getNextPageParam: (lastPage) =>
+      lastPage.hasNextPage ? lastPage.nextCursor ?? undefined : undefined,
+  });
+};

--- a/hooks/use-admin-users.ts
+++ b/hooks/use-admin-users.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { getSystemUsers, SystemUserFilter } from '@/lib/actions/admin/admin-users-action';
+import { PageResponse } from '@/lib/pagination.dto';
+import { SystemUserDTO } from '@/models/user/systemUserDTO';
+import { useAuth } from '@clerk/nextjs';
+import { useQuery } from '@tanstack/react-query';
+
+export const useSystemUsers = (filter: SystemUserFilter) => {
+  const { getToken } = useAuth();
+
+  return useQuery<PageResponse<SystemUserDTO>>({
+    queryKey: ['admin-system-users', filter],
+    queryFn: async () => {
+      const token = await getToken();
+      if (!token) throw new Error('Token is required');
+
+      return getSystemUsers(token, filter);
+    },
+    staleTime: 10_000,
+    gcTime: 120_000,
+    keepPreviousData: true,
+  });
+};

--- a/utils/user.utils.ts
+++ b/utils/user.utils.ts
@@ -1,9 +1,13 @@
+import { SystemUserDTO } from "@/models/user/systemUserDTO";
 import { UserDTO } from "@/models/user/userDTO";
 
-export function getFullName(u: UserDTO) {
+type NameableUser = Pick<UserDTO, "firstName" | "lastName"> |
+  Pick<SystemUserDTO, "firstName" | "lastName">;
+
+export function getFullName(u: NameableUser) {
   return `${u.firstName ?? ''} ${u.lastName ?? ''}`.trim();
 }
 
-export function formatDateVN(d: Date) {
+export function formatDateVN(d: Date | string) {
   return new Date(d).toLocaleDateString('vi-VN');
 }


### PR DESCRIPTION
## Summary
- add a reusable admin audit log component backed by a new useAdminAuditLogs hook
- surface user-focused admin activity logs beneath the admin users table with USER_LOG filter

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947ead4bd508333adb66a0ffd186a96)